### PR TITLE
Updated installer script URL

### DIFF
--- a/logs/recipes/install.rb
+++ b/logs/recipes/install.rb
@@ -3,7 +3,7 @@ directory "/opt/aws/cloudwatch" do
 end
 
 remote_file "/opt/aws/cloudwatch/awslogs-agent-setup-v1.0.py" do
-source "https://s3.amazonaws.com/aws-cloudwatch/downloads/awslogs-agent-setup-v1.0.py"
+source "https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py"
 mode "0755"
 end
 


### PR DESCRIPTION
Changed the installer script to point to (what I assume is) the latest version`1.3.7` rather than the old `1.0.3`. The old script was failing to install pip dependencies due to an untrusted (non-ssl) index.
